### PR TITLE
Set new Hogan.Template so that you can call Template['my/template'].render

### DIFF
--- a/tasks/hogan.js
+++ b/tasks/hogan.js
@@ -61,7 +61,7 @@ module.exports = function(grunt) {
 
         filename = options.defaultName(file);
         output.push(nsInfo.namespace +
-          "[" + JSON.stringify(filename) + "] = " + compiled + ";");
+          "[" + JSON.stringify(filename) + "] = new Hogan.Template(" + compiled + ");");
       });
 
       if(output.length > 0) {


### PR DESCRIPTION
Hey,

Thanks for writing this, its pretty useful. Had some issues using it today. I've patched it else this isn't much use on the client side. Otherwise you have to call new Hogan.Template each time which isn't very pretty.

Also could you publish this to npm.
