### PR TITLE
Fix method typo in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,7 +81,7 @@ hogan: {
       publish: {
         options: {
           prettify: true,
-          templateName: function(file) {
+          defaultName: function(file) {
             return file.toUppercase();
           }
         },


### PR DESCRIPTION
The Configuration example showed `templateName` instead of `defaultName`
