### PR TITLE
Fix multiple destination files specified.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,6 +28,12 @@ module.exports = function(grunt) {
           "build/hulked.js": ["test/fixtures/template.html"]
         }
       },
+      multiple: {
+        files:{
+          "build/first.js": ["test/fixtures/template.html"],
+          "build/second.js": ["test/fixtures/it's-a-bad-name.html"]
+        }
+      },
       badName: {
         files: {
           "build/bad.js": ["test/fixtures/*bad*"]

--- a/tasks/hogan.js
+++ b/tasks/hogan.js
@@ -72,6 +72,7 @@ module.exports = function(grunt) {
         }
         grunt.file.write(files.dest, output.join("\n\n"));
         grunt.log.writeln("File '" + files.dest + "' created.");
+        output = [];
       }
 
     });

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,23 @@ exports.hogan = {
     return test.done();
   },
 
+  multiple: function(test) {
+    var expect,
+        result;
+
+    test.expect(2);
+
+    expect = normalize(grunt.file.read("test/expected/hulked.js"));
+    result = normalize(grunt.file.read("build/first.js"));
+    test.equal(expect, result, "should compile multiple files independently");
+
+    expect = normalize(grunt.file.read("test/expected/bad.js"));
+    result = normalize(grunt.file.read("build/second.js"));
+    test.equal(expect, result, "should compile multiple files independently");
+
+    return test.done();
+  },
+
   badName: function(test) {
     var expect,
         result;


### PR DESCRIPTION
Example:

```
    files:{
      "build/first.js": ["test/fixtures/template.html"],
      "build/second.js": ["test/fixtures/it's-a-bad-name.html"]
    }
```

The previous behavior was continuing to append output as each file was processed.
