### PR TITLE
browser friendly commonJsWrapper

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,9 @@ options: {
 ```javascript
 this["Templates"] = this["Templates"] || {};
 
-module.exports = this["Templates"];
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+  module.exports = this["Templates"];
+}
 
 // with "component build" this will be wrapped in:
 // require.register("project/file", function(exports, require, module){

--- a/tasks/hogan.js
+++ b/tasks/hogan.js
@@ -86,7 +86,9 @@ module.exports = function(grunt) {
           output.push("  return " + nsInfo.namespace + ";\n});");
         }
         if(options.commonJsWrapper) {
-          output.push("module.exports = " + nsInfo.namespace + ";");
+          output.push("if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {")
+          output.push("  module.exports = " + nsInfo.namespace + ";");
+          output.push("}");
         }
         grunt.file.write(files.dest, output.join("\n\n"));
         grunt.log.writeln("File '" + files.dest + "' created.");


### PR DESCRIPTION
commonJsWrapper option was not compatible with browsers.
This patch allows template scripts could run both on node.js (CommonJS) and browsers.
