### PR TITLE
Add option to generate TypeScript definition files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,6 +86,17 @@ module.exports = function(grunt) {
         files: {
           "build/commonJsWrapper.js": ["test/fixtures/template.html"]
         }
+      },
+      typescriptDefinition: {
+        options: {
+          defaultName: function(filename) {
+            return filename.split('/').pop().replace('.html', '');
+          },
+          generateTsd: true
+        },
+        files: {
+          "build/typescriptDefinition.js": ["test/fixtures/template.html"]
+        }
       }
     }
   });

--- a/Readme.md
+++ b/Readme.md
@@ -119,6 +119,15 @@ options: {
 ### templateOptions `object`
 Any options that might need to be passed to the `Hogan.compile()` function.
 
+### generateTsd `boolean`
+Generate a TypeScript definition file alongside the output.
+
+### tsdModuleBase `string`
+When `generateTsd` is true, set the root of your TypeScript project. Optional, but highly recommended for use with `generateTsd`.
+
+### tsdExtension `string`
+When `generateTsd` is true, set the extension of the generated definition file. Defaults to `.d.ts`.
+
 ## Configuration example
 ```javascript
 hogan: {
@@ -134,6 +143,35 @@ hogan: {
         }
       }
     }
+```
+
+## TypeScript configuration example
+
+*Example:*
+```javascript
+files: [
+  {
+    expand: true,
+    cwd: 'src/templates/',
+    dest: 'src/ts/generated/templates',
+    src: ['**/*'],
+    filter: 'isFile',
+    ext: '.js'
+  }
+]
+options: {
+  generateTsd: true,
+  tsdModuleBase: 'src/ts'
+}
+```
+
+As written above, this will generate .d.ts files like this:
+```typescript
+declare module "generated/templates/myTemplate" {
+  export var myTemplate:{
+    render(params?:Object):HTMLElement;
+  };
+}
 ```
 
 ## License

--- a/tasks/hogan.js
+++ b/tasks/hogan.js
@@ -106,7 +106,7 @@ module.exports = function(grunt) {
           var jsExtension = files.orig && files.orig.ext ? files.orig.ext : '.js';
           var modName = path.relative(options.tsdModuleBase, files.dest.replace(jsExtension, ''));
 
-          var tsdTemplate = 'declare module "<%= moduleName %>" {\n  export var <%= filename %>:{\n    render(params?:Object):HTMLElement;\n  };\n}';
+          var tsdTemplate = 'declare module "<%= moduleName %>" {\n  export var <%= filename %>:{\n    render(params?:Object):string;\n  };\n}';
           var tsdOutput = grunt.template.process(tsdTemplate, {data: {moduleName: modName, filename: filename}});
           var tsdDestination = files.dest.replace('.js', options.tsdExtension);
 

--- a/test/expected/typescriptDefinition.d.ts
+++ b/test/expected/typescriptDefinition.d.ts
@@ -1,5 +1,5 @@
 declare module "build/typescriptDefinition" {
   export var template:{
-    render(params?:Object):HTMLElement;
+    render(params?:Object):string;
   };
 }

--- a/test/expected/typescriptDefinition.d.ts
+++ b/test/expected/typescriptDefinition.d.ts
@@ -1,0 +1,5 @@
+declare module "build/typescriptDefinition" {
+  export var template:{
+    render(params?:Object):HTMLElement;
+  };
+}

--- a/test/index.js
+++ b/test/index.js
@@ -128,5 +128,18 @@ exports.hogan = {
     test.equal(expect, result, "should build a template wrapped for CommonJS");
 
     return test.done();
+  },
+
+  typescriptDefinition: function(test) {
+    var expect,
+        result;
+
+    test.expect(1);
+
+    expect = normalize(grunt.file.read("test/expected/typescriptDefinition.d.ts"));
+    result = normalize(grunt.file.read("build/typescriptDefinition.d.ts"));
+    test.equal(expect, result, "should build a TypeScript definition for a template");
+
+    return test.done();
   }
 };


### PR DESCRIPTION
For TypeScript development it would be handy to be able to generate TypeScript definition files to go with each generated JavaScript file. This adds three new options to do so, which are documented in the Readme.
